### PR TITLE
Replace Ubuntu 16.04 with latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202107-02
     steps:
       - checkout
       - matlab/install

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The repository includes these files:
 ### Azure DevOps
 ```yml
 pool:
-  vmImage: Ubuntu 16.04
+  vmImage: ubuntu-latest
 steps:
   - task: InstallMATLAB@0
   - task: RunMATLABTests@0
@@ -194,7 +194,7 @@ orbs:
 jobs:
   build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202107-02
     steps:
       - checkout
       - matlab/install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: Ubuntu 16.04
+  vmImage: ubuntu-latest
 steps:
   - task: InstallMATLAB@0
   - task: RunMATLABTests@0


### PR DESCRIPTION
Ubuntu 16.04 is being removed by most CI services. This change replaces its use with the latest Ubuntu available.