### PR TITLE
Improve status table plain text readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 | Service                             | Status |
-| -------                             | ------ |
+| :------                             | :----- |
 | Azure<sup>&reg;</sup>&nbsp;DevOps   | [![Azure DevOps](https://dev.azure.com/iat-ci/ci-configuration-examples/_apis/build/status/mathworks.ci-configuration-examples)](https://dev.azure.com/iat-ci/ci-configuration-examples/_build) |
 | CircleCI<sup>&reg;</sup>            | [![CircleCI](https://circleci.com/gh/mathworks/ci-configuration-examples.svg?style=svg)](https://circleci.com/gh/mathworks/ci-configuration-examples) |
 | GitHub<sup>&reg;</sup>&nbsp;Actions | [![GitHub Actions](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml/badge.svg)](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml) |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-| **Azure<sup>&reg;</sup>&nbsp;DevOps** | **CircleCI<sup>&reg;</sup>** | **GitHub<sup>&reg;</sup>&nbsp;Actions** | **Travis&nbsp;CI&trade;** | 
-|:---------------------------|:-----------------:|:----------------------------:|:--------------------------:|
-| [![Build Status](https://dev.azure.com/iat-ci/ci-configuration-examples/_apis/build/status/mathworks.ci-configuration-examples)](https://dev.azure.com/iat-ci/ci-configuration-examples/_build) <br> ![Azure DevOps Coverage](https://img.shields.io/azure-devops/coverage/iat-ci/ci-configuration-examples/36) | [![CircleCI](https://circleci.com/gh/mathworks/ci-configuration-examples.svg?style=svg)](https://circleci.com/gh/mathworks/ci-configuration-examples) <br><br> | [![MATLAB](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml/badge.svg)](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml) <br><br> | [![Build Status](https://app.travis-ci.com/mathworks/ci-configuration-examples.svg)](https://app.travis-ci.com/mathworks/ci-configuration-examples) <br><br> |
-
+| Service                                 | Status                                  |
+|:----------------------------------------|:----------------------------------------|
+| **Azure<sup>&reg;</sup>&nbsp;DevOps**   | [![Azure DevOps](https://dev.azure.com/iat-ci/ci-configuration-examples/_apis/build/status/mathworks.ci-configuration-examples)](https://dev.azure.com/iat-ci/ci-configuration-examples/_build) ![Azure DevOps Coverage](https://img.shields.io/azure-devops/coverage/iat-ci/ci-configuration-examples/36) |
+| **CircleCI<sup>&reg;</sup>**            | [![CircleCI](https://circleci.com/gh/mathworks/ci-configuration-examples.svg?style=svg)](https://circleci.com/gh/mathworks/ci-configuration-examples) |
+| **GitHub<sup>&reg;</sup>&nbsp;Actions** | [![GitHub Actions](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml/badge.svg)](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml) |
+| **Travis&nbsp;CI&trade;**               | [![Travis CI](https://app.travis-ci.com/mathworks/ci-configuration-examples.svg)](https://app.travis-ci.com/mathworks/ci-configuration-examples) |
 
 # Continuous Integration (CI) configuration examples for MATLAB<sup>&reg;</sup>
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-| Service                                 | Status                                  |
-|:----------------------------------------|:----------------------------------------|
-| **Azure<sup>&reg;</sup>&nbsp;DevOps**   | [![Azure DevOps](https://dev.azure.com/iat-ci/ci-configuration-examples/_apis/build/status/mathworks.ci-configuration-examples)](https://dev.azure.com/iat-ci/ci-configuration-examples/_build) ![Azure DevOps Coverage](https://img.shields.io/azure-devops/coverage/iat-ci/ci-configuration-examples/36) |
-| **CircleCI<sup>&reg;</sup>**            | [![CircleCI](https://circleci.com/gh/mathworks/ci-configuration-examples.svg?style=svg)](https://circleci.com/gh/mathworks/ci-configuration-examples) |
-| **GitHub<sup>&reg;</sup>&nbsp;Actions** | [![GitHub Actions](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml/badge.svg)](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml) |
-| **Travis&nbsp;CI&trade;**               | [![Travis CI](https://app.travis-ci.com/mathworks/ci-configuration-examples.svg)](https://app.travis-ci.com/mathworks/ci-configuration-examples) |
+| Service                             | Status |
+| -------                             | ------ |
+| Azure<sup>&reg;</sup>&nbsp;DevOps   | [![Azure DevOps](https://dev.azure.com/iat-ci/ci-configuration-examples/_apis/build/status/mathworks.ci-configuration-examples)](https://dev.azure.com/iat-ci/ci-configuration-examples/_build) |
+| CircleCI<sup>&reg;</sup>            | [![CircleCI](https://circleci.com/gh/mathworks/ci-configuration-examples.svg?style=svg)](https://circleci.com/gh/mathworks/ci-configuration-examples) |
+| GitHub<sup>&reg;</sup>&nbsp;Actions | [![GitHub Actions](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml/badge.svg)](https://github.com/mathworks/ci-configuration-examples/actions/workflows/ci.yml) |
+| Travis&nbsp;CI&trade;               | [![Travis CI](https://app.travis-ci.com/mathworks/ci-configuration-examples.svg)](https://app.travis-ci.com/mathworks/ci-configuration-examples) |
 
 # Continuous Integration (CI) configuration examples for MATLAB<sup>&reg;</sup>
 


### PR DESCRIPTION
I transposed the status table at the top of the README so that it is easier to read and edit in a text editor.