### PR TITLE
Change "sourcefolder" from a sring to a list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stage('Run MATLAB Tests') {
       steps {
         runMATLABTests(
-          sourceFolder: 'code'
+          sourceFolder: ['code']
         )
 
         // As an alternative to runMATLABTests, you can use runMATLABCommand to execute a MATLAB script, function, or statement.


### PR DESCRIPTION
It looks like the Jenkinsfile included here won't actually run because it hits a type error saying that it was expecting a list instead of a string. This change fixes that.