### PR TITLE
Add env var to test online validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
       MW_DIAGNOSTIC_DEST: file
       MW_DIAGNOSTIC_SPEC: cppmicroservices::framework.*=all;install.*=all;
       MW_VERBOSE_HTTPCLIENT_CORE: 1
+      MW_BATCH_LICENSING_ONLINE: true  # testing online validation, can remove when this becomes the default
     steps:
       - checkout
       - matlab/install:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  MW_BATCH_LICENSING_ONLINE: true  # testing online validation, can remove when this becomes the default
+
 jobs:
   build-v1:
     strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ variables:
   MW_DIAGNOSTIC_DEST: file
   MW_DIAGNOSTIC_SPEC: cppmicroservices::framework.*=all;install.*=all;
   MW_VERBOSE_HTTPCLIENT_CORE: 1
+  MW_BATCH_LICENSING_ONLINE: true  # testing online validation, can remove when this becomes the default
 steps:
   - task: InstallMATLAB@1
     inputs:


### PR DESCRIPTION
Set up hourly jobs to use online validation. If things are looking good after a period of time, we can add this to our integration code.