### PR TITLE
Reenable R2025a on macos in hourly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         # Run this workflow on different os
-        os: [windows-latest, ubuntu-latest] # g3735302 [macos-latest, macos-13]
+        os: [windows-latest, ubuntu-latest, macos-latest, macos-13]
       fail-fast: false
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -109,7 +109,7 @@ jobs:
     strategy:
       matrix:
         # Run this workflow on different os
-        os: [windows-latest, ubuntu-latest] # g3735302 [macos-latest, macos-13]
+        os: [windows-latest, ubuntu-latest, macos-latest, macos-13]
       fail-fast: false
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
R2025a update 1 appears to have fixed the hang when plotting on macos.