### PR TITLE
Update .gitlab-ci.yml to use matlab build component

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,2 @@
-stages:         
-  - test
-
-matlab-test-job:       
-  stage: test
-  script:
-    - matlab -batch "addpath('code'); results = runtests('IncludeSubfolders', true); assertSuccess(results);"
+include:
+  - component: $CI_SERVER_FQDN/mathworks/components/matlab/build@~latest


### PR DESCRIPTION
We have published a [MATLAB component ](https://gitlab.com/explore/catalog/mathworks/components/matlab) to the GitLab CI/CD Catalog. This component uses the `mathworks/matlab` image and uses public licensing enabled. Update the example to use this component so that it works on gitlab.com out-of-box.