### PR TITLE
Remove macos-13 from CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         # Run this workflow on different os
-        os: [windows-latest, ubuntu-latest, macos-latest, macos-13]
+        os: [windows-latest, ubuntu-latest, macos-latest]
       fail-fast: false
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -121,7 +121,7 @@ jobs:
     strategy:
       matrix:
         # Run this workflow on different os
-        os: [windows-latest, ubuntu-latest, macos-latest, macos-13]
+        os: [windows-latest, ubuntu-latest, macos-latest]
       fail-fast: false
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The macOS-13 based runner images are being deprecated and GitHub is beginning the brownout process. For more details, see https://github.com/actions/runner-images/issues/13046.