### PR TITLE
Update macOS resource class on Circle and exclude latest-including-prerelease on Azure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ executors:
       image: ubuntu-2204:current
   macos:
     macos:
-      xcode: 14.2.0
-    resource_class: macos.m1.medium.gen1
+      xcode: 26.2.0
+    resource_class: m4pro.medium
   windows: 
     win/default
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -8,13 +8,13 @@ parameters:
   default: []    # e.g., ['R2021a', 'R2021b', ..., 'latest-including-prerelease']
 
 - name: EXCLUDED
-  type: object
-  default: []    # e.g., ['macOS-latest|latest-including-prerelease']
+  type: string
+  default: ''    # e.g., 'macOS-latest|latest-including-prerelease'
 
 jobs:
   - ${{ each image in parameters.IMAGE }}:
     - ${{ each release in parameters.RELEASE }}:
-      - ${{ if not(contains(parameters.EXCLUDED, format('{0}|{1}', image, release))) }}:
+      - ${{ if not(eq(format('{0}|{1}', image, release), parameters.EXCLUDED)) }}:
         - job:
           displayName: ${{ format('{0} {1}', image, release) }}
           pool:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,3 +1,16 @@
+parameters:
+- name: IMAGE
+  type: object
+  default: []    # e.g., ['windows-latest', 'ubuntu-latest', 'macOS-latest']
+
+- name: RELEASE
+  type: object
+  default: []    # e.g., ['R2021a', 'R2021b', ..., 'latest-including-prerelease']
+
+- name: EXCLUDED
+  type: object
+  default: []    # e.g., ['macOS-latest|latest-including-prerelease']
+
 jobs:
   - ${{ each image in parameters.IMAGE }}:
     - ${{ each release in parameters.RELEASE }}:

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -1,34 +1,35 @@
 jobs:
   - ${{ each image in parameters.IMAGE }}:
     - ${{ each release in parameters.RELEASE }}:
-      - job:
-        displayName: ${{ format('{0} {1}', image, release) }}
-        pool:
-          vmImage: ${{ image }}
-        variables:
-          MATLAB_LOG_DIR: $(Build.SourcesDirectory)/mw_logs
-          MW_INSTALLER_DDUX_LOG: $(Build.SourcesDirectory)/mw_logs/mw_installer_ddux.log
-          MW_DIAGNOSTIC_DEST: file
-          MW_DIAGNOSTIC_SPEC: cppmicroservices::framework.*=all;install.*=all;
-          MW_VERBOSE_HTTPCLIENT_CORE: 1
-          MW_BATCH_LICENSING_ONLINE: true # testing online validation, can remove when this becomes the default
-        steps:
-          - task: InstallMATLAB@1
-            inputs:
-              release: ${{ release }}
-              products: Optimization_Toolbox Curve_Fitting_Toolbox
-          - task: RunMATLABTests@1
-            inputs:
-              sourceFolder: code
-          - bash: |
-              mkdir -p $(Build.ArtifactStagingDirectory)/mw_logs
-              cp -r $(MATLAB_LOG_DIR)/* $(Build.ArtifactStagingDirectory)/mw_logs/ || true
-              cp -v /tmp/mathworks_*.log $(Build.ArtifactStagingDirectory)/mw_logs/ || true
-            condition: failed()
-            displayName: Gather MPM and MATLAB logs
-          - task: PublishBuildArtifacts@1
-            condition: failed()
-            inputs:
-              PathtoPublish: $(Build.ArtifactStagingDirectory)/mw_logs
-              ArtifactName: mw-logs
-            displayName: Publish MPM and MATLAB logs
+      - ${{ if not(contains(parameters.EXCLUDED, format('{0}|{1}', image, release))) }}:
+        - job:
+          displayName: ${{ format('{0} {1}', image, release) }}
+          pool:
+            vmImage: ${{ image }}
+          variables:
+            MATLAB_LOG_DIR: $(Build.SourcesDirectory)/mw_logs
+            MW_INSTALLER_DDUX_LOG: $(Build.SourcesDirectory)/mw_logs/mw_installer_ddux.log
+            MW_DIAGNOSTIC_DEST: file
+            MW_DIAGNOSTIC_SPEC: cppmicroservices::framework.*=all;install.*=all;
+            MW_VERBOSE_HTTPCLIENT_CORE: 1
+            MW_BATCH_LICENSING_ONLINE: true # testing online validation, can remove when this becomes the default
+          steps:
+            - task: InstallMATLAB@1
+              inputs:
+                release: ${{ release }}
+                products: Optimization_Toolbox Curve_Fitting_Toolbox
+            - task: RunMATLABTests@1
+              inputs:
+                sourceFolder: code
+            - bash: |
+                mkdir -p $(Build.ArtifactStagingDirectory)/mw_logs
+                cp -r $(MATLAB_LOG_DIR)/* $(Build.ArtifactStagingDirectory)/mw_logs/ || true
+                cp -v /tmp/mathworks_*.log $(Build.ArtifactStagingDirectory)/mw_logs/ || true
+              condition: failed()
+              displayName: Gather MPM and MATLAB logs
+            - task: PublishBuildArtifacts@1
+              condition: failed()
+              inputs:
+                PathtoPublish: $(Build.ArtifactStagingDirectory)/mw_logs
+                ArtifactName: mw-logs
+              displayName: Publish MPM and MATLAB logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,4 +3,4 @@ jobs:
     parameters:
       IMAGE: [windows-latest, ubuntu-latest, macOS-latest]
       RELEASE: [R2021a, R2021b, R2022a, R2022b, R2023a, R2023b, R2024a, R2024b, R2025a, latest, latest-including-prerelease]
-      EXCLUDED: [macOS-latest|latest-including-prerelease] # R2026a no longer supports Intel Macs but Azure does not yet have ARM Macs
+      EXCLUDED: ['macOS-latest|latest-including-prerelease'] # R2026a no longer supports Intel Macs but Azure does not yet have ARM Macs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,3 +3,4 @@ jobs:
     parameters:
       IMAGE: [windows-latest, ubuntu-latest, macOS-latest]
       RELEASE: [R2021a, R2021b, R2022a, R2022b, R2023a, R2023b, R2024a, R2024b, R2025a, latest, latest-including-prerelease]
+      EXCLUDED: [macOS-latest|latest-including-prerelease] # R2026a no longer supports Intel Macs but Azure does not yet have ARM Macs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,4 +3,4 @@ jobs:
     parameters:
       IMAGE: [windows-latest, ubuntu-latest, macOS-latest]
       RELEASE: [R2021a, R2021b, R2022a, R2022b, R2023a, R2023b, R2024a, R2024b, R2025a, latest, latest-including-prerelease]
-      EXCLUDED: ['macOS-latest|latest-including-prerelease'] # R2026a no longer supports Intel Macs but Azure does not yet have ARM Macs
+      EXCLUDED: 'macOS-latest|latest-including-prerelease' # R2026a no longer supports Intel Macs but Azure does not yet have ARM Macs


### PR DESCRIPTION
macos.m1.medium.gen1 on CircleCI has hit EOL.

Azure Pipelines also doesn't have Apple silicon runners yet and R2026a no longer supports Intel Macs, so that combo needs to be excluded from the matrix build for now.