### PR TITLE
Update gitlab example

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,2 +1,4 @@
+# Run a build using the MATLAB Build Component for GitLab CI/CD.
+# For more information see https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md.
 include:
   - component: $CI_SERVER_FQDN/mathworks/components/matlab/build@~latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,5 @@
-# Run a build using the MATLAB Build Component for GitLab CI/CD.
-# For more information see https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md.
+# This pipeline configuration uses the `build` component to run a build using the MATLAB build tool. The component runs the
+# default tasks in a build file named `buildfile.m` located in the repository, using the latest release of MATLAB.
+# For more information about the build component, see https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md.
 include:
   - component: $CI_SERVER_FQDN/mathworks/components/matlab/build@~latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 # This pipeline configuration uses the `build` component to run a build using the MATLAB build tool. The component runs the
 # default tasks in a build file named `buildfile.m` located in the repository, using the latest release of MATLAB.
-# For more information about the build component, see https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md.
+# For more information about the `build` component, see https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md.
 include:
   - component: $CI_SERVER_FQDN/mathworks/components/matlab/build@~latest

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The repository includes these files:
 | [`azure-pipelines.yml`](azure-pipelines.yml) | The [`azure-pipelines.yml`](azure-pipelines.yml) file defines the pipeline that runs using the [MATLAB extension for Azure DevOps](https://github.com/mathworks/matlab-azure-devops-extension/blob/master/overview.md). |
 | [`.circleci/config.yml`](.circleci/config.yml) | The [`config.yml`](.circleci/config.yml) file defines the pipeline that runs using the [MATLAB orb for CircleCI]([https://circleci.com/orbs/registry/orb/mathworks/matlab](https://github.com/mathworks/matlab-circleci-orb/blob/master/README.md). |
 | [`.github/workflows/ci.yml`](.github/workflows/ci.yml) | The [`ci.yml`](.github/workflows/ci.yml) file defines the pipeline that runs using the [MATLAB actions for GitHub Actions](https://github.com/matlab-actions/overview). |
-| [`Jenkinsfile`](Jenkinsfile) | The [`Jenkinsfile`](Jenkinsfile) file defines the pipeline that runs using the [MATLAB plugin for Jenkins]](https://github.com/jenkinsci/matlab-plugin/blob/master/CONFIGDOC.md). |
+| [`Jenkinsfile`](Jenkinsfile) | The [`Jenkinsfile`](Jenkinsfile) file defines the pipeline that runs using the [MATLAB plugin for Jenkins](https://github.com/jenkinsci/matlab-plugin/blob/master/CONFIGDOC.md). |
 | [`.gitlab-ci.yml`](.gitlab-ci.yml) | The [`.gitlab-ci.yml`](.gitlab-ci.yml) file defines the pipeline that runs using the [MATLAB `build` component for GitLab CI/CD](https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md). |
 
 <br>

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ The repository includes these files:
 | [`code/dayofyear.m`](code/dayofyear.m) | The [`dayofyear`](code/dayofyear.m) function returns the day-of-year number for a given date string "mm/dd/yyyy" |
 | [`tests/TestExamples.m`](tests/TestExamples.m) | The [`TestExamples`](tests/TestExamples.m) class provides a few equality and negative tests for the [`dayofyear`](code/dayofyear.m) function |
 | [`tests/ParameterizedTestExample.m`](tests/ParameterizedTestExample.m) | The [`ParameterizedTestExample`](tests/ParameterizedTestExample.m) class provides 12 tests for the [`dayofyear`](code/dayofyear.m) function using the parameterized test format |
-| [`azure-pipelines.yml`](azure-pipelines.yml) | The [`azure-pipelines.yml`](azure-pipelines.yml) file defines the pipeline that runs on [Azure DevOps](https://marketplace.visualstudio.com/items?itemName=MathWorks.matlab-azure-devops-extension). |
-| [`.circleci/config.yml`](.circleci/config.yml) | The [`config.yml`](.circleci/config.yml) file defines the pipeline that runs on [CircleCI](https://circleci.com/orbs/registry/orb/mathworks/matlab) |
-| [`.github/workflows/ci.yml`](.github/workflows/ci.yml) | The [`ci.yml`](.github/workflows/ci.yml) file defines the pipeline that runs on [GitHub Actions](https://github.com/matlab-actions/overview) |
-| [`Jenkinsfile`](Jenkinsfile) | The [`Jenkinsfile`](Jenkinsfile) file defines the pipeline that runs on [Jenkins](https://plugins.jenkins.io/matlab/) |
-| [`.gitlab-ci.yml`](.gitlab-ci.yml) | The [`.gitlab-ci.yml`](.gitlab-ci.yml) file defines the pipeline that runs on [GitLab CI/CD](https://docs.gitlab.com/ee/ci/) |
+| [`azure-pipelines.yml`](azure-pipelines.yml) | The [`azure-pipelines.yml`](azure-pipelines.yml) file defines the pipeline that runs with the [MATLAB Extension for Azure DevOps](https://github.com/mathworks/matlab-azure-devops-extension/blob/master/overview.md). |
+| [`.circleci/config.yml`](.circleci/config.yml) | The [`config.yml`](.circleci/config.yml) file defines the pipeline that runs with the [MATLAB Orb for CircleCI]([https://circleci.com/orbs/registry/orb/mathworks/matlab](https://github.com/mathworks/matlab-circleci-orb/blob/master/README.md)) |
+| [`.github/workflows/ci.yml`](.github/workflows/ci.yml) | The [`ci.yml`](.github/workflows/ci.yml) file defines the pipeline that runs with [MATLAB Actions for GitHub Actions](https://github.com/matlab-actions/overview) |
+| [`Jenkinsfile`](Jenkinsfile) | The [`Jenkinsfile`](Jenkinsfile) file defines the pipeline that runs with the [MATLAB Plugin for Jenkins](https://github.com/jenkinsci/matlab-plugin/blob/master/CONFIGDOC.md) |
+| [`.gitlab-ci.yml`](.gitlab-ci.yml) | The [`.gitlab-ci.yml`](.gitlab-ci.yml) file defines the pipeline that runs with the [MATLAB Build Component for GitLab CI/CD](https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md?ref_type=heads) |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The repository includes these files:
 | [`.circleci/config.yml`](.circleci/config.yml) | The [`config.yml`](.circleci/config.yml) file defines the pipeline that runs with the [MATLAB Orb for CircleCI]([https://circleci.com/orbs/registry/orb/mathworks/matlab](https://github.com/mathworks/matlab-circleci-orb/blob/master/README.md)) |
 | [`.github/workflows/ci.yml`](.github/workflows/ci.yml) | The [`ci.yml`](.github/workflows/ci.yml) file defines the pipeline that runs with [MATLAB Actions for GitHub Actions](https://github.com/matlab-actions/overview) |
 | [`Jenkinsfile`](Jenkinsfile) | The [`Jenkinsfile`](Jenkinsfile) file defines the pipeline that runs with the [MATLAB Plugin for Jenkins](https://github.com/jenkinsci/matlab-plugin/blob/master/CONFIGDOC.md) |
-| [`.gitlab-ci.yml`](.gitlab-ci.yml) | The [`.gitlab-ci.yml`](.gitlab-ci.yml) file defines the pipeline that runs with the [MATLAB Build Component for GitLab CI/CD](https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md?ref_type=heads) |
+| [`.gitlab-ci.yml`](.gitlab-ci.yml) | The [`.gitlab-ci.yml`](.gitlab-ci.yml) file defines the pipeline that runs with the [MATLAB Build Component for GitLab CI/CD](https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md) |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ The repository includes these files:
 
 | **File Path**              | **Description** |
 |:---------------------------|:----------------|
-| [`code/dayofyear.m`](code/dayofyear.m) | The [`dayofyear`](code/dayofyear.m) function returns the day-of-year number for a given date string "mm/dd/yyyy" |
-| [`tests/TestExamples.m`](tests/TestExamples.m) | The [`TestExamples`](tests/TestExamples.m) class provides a few equality and negative tests for the [`dayofyear`](code/dayofyear.m) function |
-| [`tests/ParameterizedTestExample.m`](tests/ParameterizedTestExample.m) | The [`ParameterizedTestExample`](tests/ParameterizedTestExample.m) class provides 12 tests for the [`dayofyear`](code/dayofyear.m) function using the parameterized test format |
-| [`azure-pipelines.yml`](azure-pipelines.yml) | The [`azure-pipelines.yml`](azure-pipelines.yml) file defines the pipeline that runs with the [MATLAB Extension for Azure DevOps](https://github.com/mathworks/matlab-azure-devops-extension/blob/master/overview.md). |
-| [`.circleci/config.yml`](.circleci/config.yml) | The [`config.yml`](.circleci/config.yml) file defines the pipeline that runs with the [MATLAB Orb for CircleCI]([https://circleci.com/orbs/registry/orb/mathworks/matlab](https://github.com/mathworks/matlab-circleci-orb/blob/master/README.md)) |
-| [`.github/workflows/ci.yml`](.github/workflows/ci.yml) | The [`ci.yml`](.github/workflows/ci.yml) file defines the pipeline that runs with [MATLAB Actions for GitHub Actions](https://github.com/matlab-actions/overview) |
-| [`Jenkinsfile`](Jenkinsfile) | The [`Jenkinsfile`](Jenkinsfile) file defines the pipeline that runs with the [MATLAB Plugin for Jenkins](https://github.com/jenkinsci/matlab-plugin/blob/master/CONFIGDOC.md) |
-| [`.gitlab-ci.yml`](.gitlab-ci.yml) | The [`.gitlab-ci.yml`](.gitlab-ci.yml) file defines the pipeline that runs with the [MATLAB Build Component for GitLab CI/CD](https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md) |
+| [`code/dayofyear.m`](code/dayofyear.m) | The [`dayofyear`](code/dayofyear.m) function returns the day-of-year number for a given date string "mm/dd/yyyy". |
+| [`tests/TestExamples.m`](tests/TestExamples.m) | The [`TestExamples`](tests/TestExamples.m) class provides a few equality and negative tests for the [`dayofyear`](code/dayofyear.m) function. |
+| [`tests/ParameterizedTestExample.m`](tests/ParameterizedTestExample.m) | The [`ParameterizedTestExample`](tests/ParameterizedTestExample.m) class provides 12 tests for the [`dayofyear`](code/dayofyear.m) function using the parameterized test format. |
+| [`azure-pipelines.yml`](azure-pipelines.yml) | The [`azure-pipelines.yml`](azure-pipelines.yml) file defines the pipeline that runs using the [MATLAB extension for Azure DevOps](https://github.com/mathworks/matlab-azure-devops-extension/blob/master/overview.md). |
+| [`.circleci/config.yml`](.circleci/config.yml) | The [`config.yml`](.circleci/config.yml) file defines the pipeline that runs using the [MATLAB orb for CircleCI]([https://circleci.com/orbs/registry/orb/mathworks/matlab](https://github.com/mathworks/matlab-circleci-orb/blob/master/README.md). |
+| [`.github/workflows/ci.yml`](.github/workflows/ci.yml) | The [`ci.yml`](.github/workflows/ci.yml) file defines the pipeline that runs using the [MATLAB actions for GitHub Actions](https://github.com/matlab-actions/overview). |
+| [`Jenkinsfile`](Jenkinsfile) | The [`Jenkinsfile`](Jenkinsfile) file defines the pipeline that runs using the [MATLAB plugin for Jenkins]](https://github.com/jenkinsci/matlab-plugin/blob/master/CONFIGDOC.md). |
+| [`.gitlab-ci.yml`](.gitlab-ci.yml) | The [`.gitlab-ci.yml`](.gitlab-ci.yml) file defines the pipeline that runs using the [MATLAB `build` component for GitLab CI/CD](https://gitlab.com/mathworks/components/matlab/-/blob/main/README.md). |
 
 <br>
 


### PR DESCRIPTION
Add some comments to .gitlab-ci.yml to link to component documentation, and update links in README to point to documentation for each CI offering.

Closes: #69 