### PR TITLE
Add workflow to notify on warnings in MATLAB matrix build

### DIFF
--- a/.github/workflows/notify-on-warnings.yml
+++ b/.github/workflows/notify-on-warnings.yml
@@ -22,21 +22,23 @@ jobs:
           script: |
             const {owner, repo} = context.repo;
             const wr = context.payload.workflow_run;
-            const sha = wr.head_sha;
+
+            // workflow_dispatch has no workflow_run payload; fall back to HEAD
+            const sha = wr?.head_sha ?? context.sha;
+            const runUrl = wr ? `https://github.com/${owner}/${repo}/actions/runs/${wr.id}` : "";
 
             // 1) All check runs for this commit
-            const result = await github.paginate(
+            const checkRuns = await github.paginate(
               github.rest.checks.listForRef,
               { owner, repo, ref: sha, per_page: 100 }
             );
-            const checkRuns = result.check_runs ?? [];
 
-            // 2) Only GitHub Actions runs whose names start with build-v2 or build-v2-with-cache
-            const prefixes = [/^build-v2(\b| |\()/, /^build-v2-with-cache(\b| |\()/];
+            // 2) Only GitHub Actions runs whose names start with build-v2
+            const prefix = /^build-v2(\b| |\()/;
             const wanted = checkRuns.filter(run => {
               const name = run.name || "";
               const fromActions = run.app?.slug === "github-actions";
-              return fromActions && prefixes.some(rx => rx.test(name));
+              return fromActions && prefix.test(name);
             });
 
             // 3) Collect warning annotations
@@ -59,12 +61,13 @@ jobs:
               }
             }
 
-            // 4) Build a clean, YAML-safe body
+            // 4) Build the email body
             const headLines = [
               `Repository: ${owner}/${repo}`,
-              `Workflow: ${wr.name} (#${wr.run_number})`,
-              `Branch: ${wr.head_branch}`,
+              `Workflow: ${wr?.name ?? "manual"} (#${wr?.run_number ?? "N/A"})`,
+              `Branch: ${wr?.head_branch ?? "N/A"}`,
               `Commit: ${sha}`,
+              ...(runUrl ? [`Run: ${runUrl}`] : []),
               "",
               `Found ${warnings.length} warning annotation(s) in build-v2 jobs.`
             ];
@@ -76,14 +79,17 @@ jobs:
               return [
                 `${i + 1}. [${w.check_run}] ${w.path}${loc}${title}`,
                 `   ${w.message}`,
-                "" // blank line between items
+                ""
               ];
             });
 
             const body = [...headLines, ...(warnings.length ? ["", `Top ${Math.min(maxItems, warnings.length)} warning(s):`, ""] : []), ...listLines].join("\n");
 
             core.setOutput("count", String(warnings.length));
-            core.setOutput("summary", body);
+
+            // Write body to file to avoid YAML injection from annotation content
+            const fs = require("fs");
+            fs.writeFileSync(process.env.GITHUB_WORKSPACE + "/warning-summary.txt", body);
 
       - name: Send mail when warnings were found
         if: steps.find.outputs.count != '0'
@@ -99,4 +105,4 @@ jobs:
           to: ${{ secrets.CI_INTERNAL_EMAIL }}
           from: ${{ secrets.MAIL_USERNAME }}
           secure: true
-          body: ${{ steps.find.outputs.summary }}
+          body: file://warning-summary.txt

--- a/.github/workflows/notify-on-warnings.yml
+++ b/.github/workflows/notify-on-warnings.yml
@@ -1,10 +1,7 @@
 name: Notify on Warnings (MATLAB matrix build)
 
 on:
-  workflow_run:
-    workflows: ["MATLAB matrix build"]
-    types: [completed]
-  workflow_dispatch: # allow manual triggering for testing
+  workflow_dispatch: # manual triggering only; workflow_run only works on the default branch
 
 permissions:
   contents: read

--- a/.github/workflows/notify-on-warnings.yml
+++ b/.github/workflows/notify-on-warnings.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["MATLAB matrix build"]
     types: [completed]
+  workflow_dispatch: # allow manual triggering for testing
 
 permissions:
   contents: read

--- a/.github/workflows/notify-on-warnings.yml
+++ b/.github/workflows/notify-on-warnings.yml
@@ -87,6 +87,9 @@ jobs:
 
             core.setOutput("count", String(warnings.length));
 
+            const subject = `⚠️ Warnings in build-v2 jobs — ${owner}/${repo} (run #${wr?.run_number ?? "N/A"} on ${wr?.head_branch ?? "N/A"})`;
+            core.setOutput("subject", subject);
+
             // Write body to file to avoid YAML injection from annotation content
             const fs = require("fs");
             fs.writeFileSync(process.env.GITHUB_WORKSPACE + "/warning-summary.txt", body);
@@ -99,9 +102,7 @@ jobs:
           server_port: 465
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
-          subject: >
-            :warning: Warnings in build-v2 jobs — ${{ github.repository }}
-            (run #${{ github.event.workflow_run.run_number }} on ${{ github.event.workflow_run.head_branch }})
+          subject: ${{ steps.find.outputs.subject }}
           to: ${{ secrets.CI_INTERNAL_EMAIL }}
           from: ${{ secrets.MAIL_USERNAME }}
           secure: true

--- a/.github/workflows/notify-on-warnings.yml
+++ b/.github/workflows/notify-on-warnings.yml
@@ -1,0 +1,101 @@
+name: Notify on Warnings (MATLAB matrix build)
+
+on:
+  workflow_run:
+    workflows: ["MATLAB matrix build"]
+    types: [completed]
+
+permissions:
+  contents: read
+  checks: read
+
+jobs:
+  notify-on-warnings:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Find warnings in build-v2* jobs
+        id: find
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const wr = context.payload.workflow_run;
+            const sha = wr.head_sha;
+
+            // 1) All check runs for this commit
+            const result = await github.paginate(
+              github.rest.checks.listForRef,
+              { owner, repo, ref: sha, per_page: 100 }
+            );
+            const checkRuns = result.check_runs ?? [];
+
+            // 2) Only GitHub Actions runs whose names start with build-v2 or build-v2-with-cache
+            const prefixes = [/^build-v2(\b| |\()/, /^build-v2-with-cache(\b| |\()/];
+            const wanted = checkRuns.filter(run => {
+              const name = run.name || "";
+              const fromActions = run.app?.slug === "github-actions";
+              return fromActions && prefixes.some(rx => rx.test(name));
+            });
+
+            // 3) Collect warning annotations
+            const warnings = [];
+            for (const run of wanted) {
+              const anns = await github.paginate(
+                github.rest.checks.listAnnotations,
+                { owner, repo, check_run_id: run.id, per_page: 100 }
+              );
+              for (const a of anns) {
+                if (a.annotation_level === "warning") {
+                  warnings.push({
+                    check_run: run.name,
+                    path: a.path,
+                    line: a.start_line,
+                    title: a.title || "",
+                    message: a.message || ""
+                  });
+                }
+              }
+            }
+
+            // 4) Build a clean, YAML-safe body
+            const headLines = [
+              `Repository: ${owner}/${repo}`,
+              `Workflow: ${wr.name} (#${wr.run_number})`,
+              `Branch: ${wr.head_branch}`,
+              `Commit: ${sha}`,
+              "",
+              `Found ${warnings.length} warning annotation(s) in build-v2 jobs.`
+            ];
+
+            const maxItems = 30;
+            const listLines = warnings.slice(0, maxItems).flatMap((w, i) => {
+              const loc = w.line ? `:${w.line}` : "";
+              const title = w.title ? ` • ${w.title}` : "";
+              return [
+                `${i + 1}. [${w.check_run}] ${w.path}${loc}${title}`,
+                `   ${w.message}`,
+                "" // blank line between items
+              ];
+            });
+
+            const body = [...headLines, ...(warnings.length ? ["", `Top ${Math.min(maxItems, warnings.length)} warning(s):`, ""] : []), ...listLines].join("\n");
+
+            core.setOutput("count", String(warnings.length));
+            core.setOutput("summary", body);
+
+      - name: Send mail when warnings were found
+        if: steps.find.outputs.count != '0'
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{ secrets.MAIL_USERNAME }}
+          password: ${{ secrets.MAIL_PASSWORD }}
+          subject: >
+            :warning: Warnings in build-v2 jobs — ${{ github.repository }}
+            (run #${{ github.event.workflow_run.run_number }} on ${{ github.event.workflow_run.head_branch }})
+          to: ${{ secrets.CI_INTERNAL_EMAIL }}
+          from: ${{ secrets.MAIL_USERNAME }}
+          secure: true
+          body: ${{ steps.find.outputs.summary }}

--- a/.github/workflows/notify-on-warnings.yml
+++ b/.github/workflows/notify-on-warnings.yml
@@ -18,11 +18,8 @@ jobs:
         with:
           script: |
             const {owner, repo} = context.repo;
-            const wr = context.payload.workflow_run;
-
-            // workflow_dispatch has no workflow_run payload; fall back to HEAD
-            const sha = wr?.head_sha ?? context.sha;
-            const runUrl = wr ? `https://github.com/${owner}/${repo}/actions/runs/${wr.id}` : "";
+            const sha = context.sha;
+            const branch = context.ref.replace(/^refs\/heads\//, "");
 
             // 1) All check runs for this commit
             const checkRuns = await github.paginate(
@@ -61,10 +58,8 @@ jobs:
             // 4) Build the email body
             const headLines = [
               `Repository: ${owner}/${repo}`,
-              `Workflow: ${wr?.name ?? "manual"} (#${wr?.run_number ?? "N/A"})`,
-              `Branch: ${wr?.head_branch ?? "N/A"}`,
+              `Branch: ${branch}`,
               `Commit: ${sha}`,
-              ...(runUrl ? [`Run: ${runUrl}`] : []),
               "",
               `Found ${warnings.length} warning annotation(s) in build-v2 jobs.`
             ];
@@ -84,7 +79,7 @@ jobs:
 
             core.setOutput("count", String(warnings.length));
 
-            const subject = `⚠️ Warnings in build-v2 jobs — ${owner}/${repo} (run #${wr?.run_number ?? "N/A"} on ${wr?.head_branch ?? "N/A"})`;
+            const subject = `⚠️ Warnings in build-v2 jobs — ${owner}/${repo} (${branch})`;
             core.setOutput("subject", subject);
 
             // Write body to file to avoid YAML injection from annotation content


### PR DESCRIPTION
This PR adds an automated notification mechanism that emails the CI team when warning annotations occur in the build-v2 or build-v2-with-cache matrix jobs of the MATLAB matrix build workflow.

The goal is to surface important non‑fatal issues (for example, deprecation warnings) that do not currently fail the workflow and therefore do not trigger existing failure‑based email alerts.